### PR TITLE
Build github zipball `dist` download URLs where possible

### DIFF
--- a/src/FitchLearning/Satisfy/Application.php
+++ b/src/FitchLearning/Satisfy/Application.php
@@ -199,6 +199,13 @@ class Application
                     "reference" => $ref
                 ];
 
+                if ($downloadUrl = $this->getZipDownloadUrl($vcsUrl, $ref)) {
+                    $packageDefinition['dist'] = [
+                        'url'  => $downloadUrl,
+                        'type' => 'zip',
+                    ];
+                }
+
                 $foundPackages[] = [
                     "type" => "package",
                     "package" => $packageDefinition
@@ -208,6 +215,22 @@ class Application
         $repoDefinition['repositories'] = array_merge($repoDefinition['repositories'], $foundPackages);
 
         return $repoDefinition;
+    }
+    
+    /**
+     * @param string $vcsUrl
+     * @param string $ref
+     *
+     * @return string
+     */
+    protected function getZipDownloadUrl($vcsUrl, $ref)
+    {
+        if (preg_match('#https://github.com/([^/]+)/([^/]+?)(\.git)?$#', $vcsUrl, $matches)) {
+            // Build github zipball download URL where possible
+            return 'https://api.github.com/repos/'.$matches[1].'/'.$matches[2].'/zipball/'.$ref;
+        }
+
+        return NULL;
     }
 
     /**


### PR DESCRIPTION
If the package source url is a github repository, then this can be translated
into a github API download path for a zipball of the given reference, rather
than forcing a source URL.