### PR TITLE
Respect optional "minversion" flag in package definition

### DIFF
--- a/src/FitchLearning/Satisfy/Application.php
+++ b/src/FitchLearning/Satisfy/Application.php
@@ -178,6 +178,9 @@ class Application
             $refs = $this->getRemoteUrlRefs($vcsUrl);
 
             foreach ($refs as $version => $ref) {
+                if ( ! $this->shouldIncludeVersion($definition, $version)) {
+                    continue;
+                }
 
                 if (isset($definition['defaults'])) {
                     $packageDefinition = $definition['defaults'];
@@ -208,6 +211,27 @@ class Application
         $repoDefinition['repositories'] = array_merge($repoDefinition['repositories'], $foundPackages);
 
         return $repoDefinition;
+    }
+    
+    /**
+     * @param array  $definition
+     * @param string $version
+     *
+     * @return bool
+     */
+    protected function shouldIncludeVersion($definition, $version)
+    {
+        if ( ! isset($definition['minversion'])) {
+            return true;
+        }
+
+        if ( ! preg_match('#^(dev-)?([0-9\.]+)$#', $version, $matches)) {
+            // version is not a numeric version or branch, so can't be compared
+            return true;
+        }
+
+        $numeric_version = array_pop($matches);
+        return version_compare($numeric_version, $definition['minversion']) >= 0;
     }
 
     /**


### PR DESCRIPTION
The documented `minversion` option isn't actually used, implement
logic to skip over numeric package versions that don't meet the 
minimum version criteria.